### PR TITLE
Removal of parallelisation in makegrid and optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ gimble tally -z analysis.z -k 2,2,2,2 -l windows_kmax2 -t windows
 ```
 gimble optimize -z analysis.z -l IM_BA_optimize -d tally/windows_kmax2 \
     -w -m IM_BA -r A -u 2.9e-09 -A 10_000,2_500_000 -B 10_000,1_000_000 \
-    -C 1_000_000,5_000_000 -M 0,1e-5 -T 0,5_000_000 -g CRS2 -p 1 -e 19 -i 10_000
+    -C 1_000_000,5_000_000 -M 0,1e-5 -T 0,5_000_000 -g CRS2 -e 19 -i 10_000
 ```
 
 ## makegrid
@@ -208,7 +208,7 @@ gimble makegrid -z analysis.z -m IM_AB \
     -B=100_000,2_000_000,12,lin \
     -C 100_000,2_000_000,12,lin \
     -T 4_256_034 -M 0,2.21E-06,16,lin \
-    -p 48 -e 19 -l IM_BA_grid
+    -e 19 -l IM_BA_grid
 ```
 
 ## gridsearch

--- a/cli/makegrid.py
+++ b/cli/makegrid.py
@@ -1,7 +1,7 @@
 """
 usage: gimble makegrid                  (-z <z> | -o <o>) -l <l> -m <m> -b <b> -r <r> -u <o> 
                                         [-k <k>] -A <A> -B <B> [-C <C>] [-T <T>] [-M <M>] 
-                                        [-p <p> -e <e>] [-f] [-h|--help]
+                                        [-e <e>] [-f] [-h|--help]
                                                  
         -z, --zarr_file=<z>             Path to existing GimbleStore 
         -o, --outprefix=<o>             Prefix to use for GimbleStore [default: gimble]
@@ -33,7 +33,6 @@ usage: gimble makegrid                  (-z <z> | -o <o>) -l <l> -m <m> -b <b> -
                                             - MIG_AB and IM_AB: A->B 
                                             - MIG_BA and IM_BA: B->A
     [Options]
-        -p, --processes=<p>             Number of processes [default: 1] 
         -e, --seed=<e>                  Seed used for randomness [default: 19]
         -f, --force                     Force overwrite of existing grid in GimbleStore
         -h --help                       Show this
@@ -62,7 +61,7 @@ class MakeGridParameterObj(lib.runargs.RunArgs):
         self.ref_pop = self._get_ref_pop(args['--ref_pop'])
         self.mu = self._get_float(args['--mu']) 
         self.kmax = self._check_kmax(args['--kmax']) 
-        self.processes = self._get_int(args['--processes']) 
+        self.processes = 1 #self._get_int(args['--processes']) 
         self.seed = self._get_int(args['--seed']) 
         self.overwrite = args['--force']
     

--- a/cli/optimize.py
+++ b/cli/optimize.py
@@ -2,7 +2,7 @@
 usage: gimble optimize                      -z <z> -l <l> -d <d> [-w] 
                                             [-y <y>] -m <m> -r <r> -u <u>
                                             [-T <T>] [-M <M>] -A <A> -B <B> [-C <C>] 
-                                            [-g <g>] [-p <p>] [-s <s>] [-i <i>] [--xtol <xtol>] [--ftol <ftol>] 
+                                            [-g <g>] [-s <s>] [-i <i>] [--xtol <xtol>] [--ftol <ftol>] 
                                             [-e <e>] [-f] [-h|--help]
 
         -z, --zarr_file=<z>                 Path to existing GimbleStore 
@@ -40,7 +40,6 @@ usage: gimble optimize                      -z <z> -l <l> -d <d> [-w]
                                                 - CRS2
                                                 - sbplx
                                                 - neldermead
-        -p, --processes=<p>                 Number of processes. Only relevant for optimization of windows [default: 1] 
         -s, --start_point=<s>               Point from which to start optimization [default: midpoint]
                                                 - 'midpoint' : midpoint between all boundary values
                                                 - 'random': based on random seed in INI file
@@ -88,7 +87,7 @@ class OptimizeParameterObj(lib.runargs.RunArgs):
         self.sync_pops = self._get_sync_pops(args['--sync_pops'])
         self.ref_pop = self._get_ref_pop(args['--ref_pop'])
         self.mu = self._get_float(args['--mu']) 
-        self.processes = self._get_int(args['--processes']) 
+        self.processes = 1 #self._get_int(args['--processes']) 
         self.seed = self._get_int(args['--seed']) 
         self.overwrite = args['--force']
         self.algorithm = self._get_nlopt_algorithm_name(args['--algorithm'])

--- a/lib/gimble.py
+++ b/lib/gimble.py
@@ -3119,20 +3119,21 @@ class Store(object):
                 print(float(parameter[0]), [float(x) for x in parameter[1]], float(parameter[2]), parameter[3])
         all_ETPs = []
         print("[+] Calculating probabilities of mutation configurations under %s parameter combinations" % len(agemo_parameters))
-        if processes==1:
-            for agemo_parameter in tqdm(agemo_parameters, desc="[%] Progress", ncols=100):
-                theta_branch, var, time, fallback_flag = agemo_parameter
-                evaluator = evaluator_agemo if not fallback_flag else fallback_evaluator
-                result = evaluator.evaluate(theta_branch, var, time=time)
-                all_ETPs.append(result)
-        else:
-            global EVALUATOR
-            global FALLBACK_EVALUATOR
-            EVALUATOR = evaluator_agemo
-            FALLBACK_EVALUATOR = fallback_evaluator
-            with multiprocessing.Pool(processes=processes) as pool:
-                for ETP in pool.starmap(self.multi_eval, tqdm(agemo_parameters, ncols=100, desc="[%] Progress")):
-                    all_ETPs.append(ETP)
+        #if processes==1:
+        for agemo_parameter in tqdm(agemo_parameters, desc="[%] Progress", ncols=100):
+            theta_branch, var, time, fallback_flag = agemo_parameter
+            evaluator = evaluator_agemo if not fallback_flag else fallback_evaluator
+            result = evaluator.evaluate(theta_branch, var, time=time)
+            all_ETPs.append(result)
+        # parallelisation does not work since agemo_evaluator.evaluate() can't be pickled ...
+        #else:
+        #    global EVALUATOR
+        #    global FALLBACK_EVALUATOR
+        #    EVALUATOR = evaluator_agemo
+        #    FALLBACK_EVALUATOR = fallback_evaluator
+        #    with multiprocessing.Pool(processes=processes) as pool:
+        #        for ETP in pool.starmap(self.multi_eval, tqdm(agemo_parameters, ncols=100, desc="[%] Progress")):
+        #            all_ETPs.append(ETP)
         print("[+] Checking probabilities for anomalies ...")
         anomaly_count = 0
         for idx, etps in enumerate(all_ETPs):
@@ -3145,10 +3146,10 @@ class Store(object):
             print("[+] No anomalies found. All is well.")
         return np.array(all_ETPs, dtype=np.float64)
 
-    def multi_eval(self, theta_branch, var, time, fallback_flag):
-        #theta_branch, var, time, fallback_flag = agemo_parameter
-        evaluator = EVALUATOR if not fallback_flag else FALLBACK_EVALUATOR
-        return evaluator.evaluate(theta_branch, var, time=time) 
+    #def multi_eval(self, theta_branch, var, time, fallback_flag):
+    #    #theta_branch, var, time, fallback_flag = agemo_parameter
+    #    evaluator = EVALUATOR if not fallback_flag else FALLBACK_EVALUATOR
+    #    return evaluator.evaluate(theta_branch, var, time=time) 
 
     def get_agemo_evaluator(self, model=None, kmax=None, seed=None):
         mutation_shape = tuple(kmax + 2)


### PR DESCRIPTION
Removed parallelisation in `makegrid` and `optimize` since there are issues in Python3.8+ due to unpickability of `agemo.evaluator.evaluate()` functions, which used to work in Python3.7 ...

There are probably ways of solving this (at least for makegrid) but the easiest solution for now is to limit these modules to one process.

Not sure whether this is related to issue #114 (i still have not been able to replicate this).

@GertjanBisschop : how do i tell pypi/conda about this? or can you?

cheers, 

dom